### PR TITLE
[containers-ordered-strict]: reexported functions from containers

### DIFF
--- a/containers-ordered-strict/src/Map/Ord.hs
+++ b/containers-ordered-strict/src/Map/Ord.hs
@@ -5,7 +5,7 @@ module Map.Ord
        , Key
 
        , M.empty
-       , M.singleton
+       , singleton
        , M.fromList
 
        , M.null
@@ -41,3 +41,6 @@ toList = M.toList
 
 keys :: Key k => Map k v -> [k]
 keys = M.keys
+
+singleton :: Key k => k -> v -> Map k v
+singleton = M.singleton

--- a/containers-ordered-strict/src/Map/Ord.hs
+++ b/containers-ordered-strict/src/Map/Ord.hs
@@ -4,26 +4,26 @@ module Map.Ord
        ( Map
        , Key
 
-       , empty
-       , singleton
-       , fromList
+       , M.empty
+       , M.singleton
+       , M.fromList
 
-       , null
-       , size
-       , member
-       , lookup
+       , M.null
+       , M.size
+       , M.member
+       , M.lookup
        , lookupDefault
 
        , toList
        , keys
-       , elems
+       , M.elems
 
-       , insert
-       , insertWith
-       , adjust
-       , update
-       , delete
-       , alter
+       , M.insert
+       , M.insertWith
+       , M.adjust
+       , M.update
+       , M.delete
+       , M.alter
        ) where
 
 import Prelude hiding (lookup, null)
@@ -33,27 +33,6 @@ import qualified Data.Map.Strict as M
 type Map = M.Map
 type Key = Ord
 
-empty :: Map k v
-empty = M.empty
-
-singleton :: Key k => k -> v -> Map k v
-singleton = M.singleton
-
-fromList :: Key k => [(k, v)] -> Map k v
-fromList = M.fromList
-
-null :: Map k v -> Bool
-null = M.null
-
-size :: Map k v -> Int
-size = M.size
-
-member :: Key k => k -> Map k a -> Bool
-member = M.member
-
-lookup :: Key k => k -> Map k v -> Maybe v
-lookup = M.lookup
-
 lookupDefault :: Key k => v -> k -> Map k v -> v
 lookupDefault = M.findWithDefault
 
@@ -62,24 +41,3 @@ toList = M.toList
 
 keys :: Key k => Map k v -> [k]
 keys = M.keys
-
-elems :: Map k v -> [v]
-elems = M.elems
-
-insert :: Key k => k -> v -> Map k v -> Map k v
-insert = M.insert
-
-insertWith :: Key k => (v -> v -> v) -> k -> v -> Map k v -> Map k v
-insertWith = M.insertWith
-
-adjust :: Key k => (a -> a) -> k -> Map k a -> Map k a
-adjust = M.adjust
-
-update :: Key k => (a -> Maybe a) -> k -> Map k a -> Map k a
-update = M.update
-
-delete :: Key k => k -> Map k v -> Map k v
-delete = M.delete
-
-alter :: Key k => (Maybe v -> Maybe v) -> k -> Map k v -> Map k v
-alter = M.alter


### PR DESCRIPTION
reexported functions except for lookupDefault, toList, keys due to
different type constraints.

r/t https://github.com/kowainik/containers-backpack/issues/24